### PR TITLE
Qusiby needs to work with results versioning

### DIFF
--- a/quisby/benchmarks/auto_hpl/extract.py
+++ b/quisby/benchmarks/auto_hpl/extract.py
@@ -2,21 +2,24 @@ import logging
 from typing import List, Dict, Optional
 from pathlib import Path
 from quisby.benchmarks.linpack.extract import linpack_format_data
+from quisby.benchmarks.version_util import get_version_info
 
 
 logger = logging.getLogger(__name__)
 
 
-def extract_auto_hpl_data(
+def _extract_v1_format(
         path: str,
-        system_name: str
+        system_name: str,
+        version_info: Dict
 ) -> Optional[List[Dict[str, str]]]:
     """
-    Extract Auto HPL benchmark data from a CSV file.
+    Extract Auto HPL benchmark data from v1.x CSV format.
 
     Args:
         path (str): Path to the CSV file
         system_name (str): Name of the system being analyzed
+        version_info (Dict): Version information from CSV
 
     Returns:
         Optional[List[Dict[str, str]]]: Processed benchmark results or None
@@ -81,4 +84,52 @@ def extract_auto_hpl_data(
             gflops=data_dict["Gflops"]
         )
 
+        # Add version info to results
+        if formatted_results:
+            csv_version = version_info['raw'] or '1.0'
+            for result in formatted_results:
+                result['csv_version'] = csv_version
+
         return formatted_results if formatted_results else None
+
+
+def extract_auto_hpl_data(
+        path: str,
+        system_name: str
+) -> Optional[List[Dict[str, str]]]:
+    """
+    Extract Auto HPL benchmark data with version awareness.
+
+    Dispatches to appropriate handler based on CSV version.
+    Supports backward compatibility for older CSV formats.
+
+    Args:
+        path (str): Path to the CSV file
+        system_name (str): Name of the system being analyzed
+
+    Returns:
+        Optional[List[Dict[str, str]]]: Processed benchmark results or None
+
+    Raises:
+        FileNotFoundError: If the specified file does not exist
+        PermissionError: If there are insufficient permissions to read the file
+        ValueError: If the file format is incorrect
+    """
+    # Get version information from CSV
+    version_info = get_version_info(path)
+    normalized_version = version_info['normalized']
+
+    logger.debug(
+        f"Processing Auto HPL CSV version {version_info['raw']} "
+        f"(normalized: {normalized_version})"
+    )
+
+    # Dispatch to version-specific handler
+    if normalized_version in ['1.0', '1.1']:
+        return _extract_v1_format(path, system_name, version_info)
+    else:
+        # Future: Add elif for version '2.0', '3.0', etc.
+        logger.warning(
+            f"Unknown CSV version {normalized_version}, attempting v1.x format"
+        )
+        return _extract_v1_format(path, system_name, version_info)

--- a/quisby/benchmarks/auto_hpl/extract.py
+++ b/quisby/benchmarks/auto_hpl/extract.py
@@ -57,13 +57,13 @@ def _extract_v1_format(
         for index, data in enumerate(file_data):
             if "Gflops" in data:
                 data_index = index
-                header_row = data.strip("\n").split(":")
+                header_row = data.strip("\n").split(",")
 
         if not header_row:
             raise KeyError("Missing 'Gflops' in data")
 
         if len(file_data) > data_index+1:
-            data_row = file_data[data_index+1].strip().split(":")
+            data_row = file_data[data_index+1].strip().split(",")
 
         # Check if insufficient data
         if not data_row:

--- a/quisby/benchmarks/coremark/coremark.py
+++ b/quisby/benchmarks/coremark/coremark.py
@@ -231,11 +231,11 @@ def _extract_coremark_v1(path, system_name, OS_RELEASE, version_info):
         for index, data in enumerate(coremark_results):
             if "iteration" in data:
                 data_index = index
-                header = data.strip("\n").split(":")
+                header = data.strip("\n").split(",")
                 # Add CSV Version to header
                 header.append("CSV Version")
             else:
-                coremark_results[index] = data.strip("\n").split(":")
+                coremark_results[index] = data.strip("\n").split(",")
         coremark_results = [header] + coremark_results[data_index + 1:]
 
         # Format the data for report generation

--- a/quisby/benchmarks/coremark_pro/coremark_pro.py
+++ b/quisby/benchmarks/coremark_pro/coremark_pro.py
@@ -1,12 +1,9 @@
+import math
 import re
-from itertools import groupby
-
 from quisby import custom_logger
-from quisby.util import read_config
 from quisby.pricing.cloud_pricing import get_cloud_pricing
-
-from quisby.util import process_instance, mk_int
-
+from quisby.util import read_config
+from quisby.benchmarks.version_util import get_version_info
 
 def extract_prefix_and_number(input_string):
     """
@@ -49,6 +46,67 @@ def custom_key(item):
         return "", ""
 
 
+def _extract_v1_format(path, system_name, OS_RELEASE, version_info):
+    """
+    Extract CoreMark-Pro data in v1.x CSV format.
+
+    Format: colon-delimited CSV with # commented metadata
+    """
+    try:
+        if not path.endswith(".csv"):
+            return None
+        with open(path) as file:
+            lines = file.readlines()
+    except Exception as exc:
+        custom_logger.error(f"Unable to open or read file for CoreMark Pro: {path}")
+        return None
+
+    header, data_rows = [], []
+    for line in lines:
+        if line.strip().startswith('#') or not line.strip(): continue
+        if not header:
+            header = [h.strip() for h in line.strip().split(':')]
+        else:
+            data_rows.append([d.strip() for d in line.strip().split(':')])
+
+    if not header or not data_rows: return None
+
+    # Include version info in results
+    csv_version = version_info['raw'] or '1.0'
+    processed_results = [
+        ['System', system_name, OS_RELEASE],
+        ['CSV_Version', csv_version],
+        header
+    ] + data_rows
+    return [processed_results]
+
+
+def extract_coremark_pro_data(path, system_name, OS_RELEASE):
+    """
+    Extract CoreMark-Pro data with version awareness.
+
+    Dispatches to appropriate handler based on CSV version.
+    Supports backward compatibility for older CSV formats.
+    """
+    # Get version information from CSV
+    version_info = get_version_info(path)
+    normalized_version = version_info['normalized']
+
+    custom_logger.debug(
+        f"Processing CoreMark-Pro CSV version {version_info['raw']} "
+        f"(normalized: {normalized_version})"
+    )
+
+    # Dispatch to version-specific handler
+    if normalized_version in ['1.0', '1.1']:
+        return _extract_v1_format(path, system_name, OS_RELEASE, version_info)
+    else:
+        # Future: Add elif for version '2.0', '3.0', etc.
+        custom_logger.warning(
+            f"Unknown CSV version {normalized_version}, attempting v1.x format"
+        )
+        return _extract_v1_format(path, system_name, OS_RELEASE, version_info)
+
 def calc_price_performance(inst, avg):
     """
     Calculate price-perf ratio for an instance based on its cost per hour and performance.
@@ -70,147 +128,54 @@ def calc_price_performance(inst, avg):
         custom_logger.error("Error calculating price-performance!")
     return cost_per_hour, price_perf
 
-
-def group_data(results):
-    """
-    Group data based on cloud type and instance attributes.
-
-    :param results: List of results to group.
-    :return: Grouped results.
-    """
-    cloud_type = read_config("cloud", "cloud_type")
-    if cloud_type == "aws":
-        return groupby(results, key=lambda x: process_instance(x[1][0], "family", "version", "feature", "machine_type"))
-    elif cloud_type == "azure":
-        results = sorted(results, key=lambda x: process_instance(x[1][0], "family", "feature"))
-        return groupby(results, key=lambda x: process_instance(x[1][0], "family", "version", "feature"))
-    elif cloud_type == "gcp":
-        return groupby(results, key=lambda x: process_instance(x[1][0], "family", "version", "sub_family", "feature"))
-    elif cloud_type == "local":
-        return groupby(results, key=lambda x: process_instance(x[1][0], "family"))
-
-
-def sort_data(results):
-    """
-    Sort data based on cloud type and instance attributes.
-
-    :param results: List of results to sort.
-    """
-    cloud_type = read_config("cloud", "cloud_type")
-    if cloud_type == "aws":
-        results.sort(key=lambda x: str(process_instance(x[1][0], "family")))
-    elif cloud_type == "azure":
-        results.sort(key=lambda x: str(process_instance(x[1][0], "family", "version", "feature")))
-    elif cloud_type == "gcp":
-        results.sort(key=lambda x: str(process_instance(x[1][0], "family", "version", "sub_family")))
-
-
 def create_summary_coremark_pro_data(results, OS_RELEASE):
     """
-    Create a summary of the CoreMark Pro data, including price-performance and iteration details.
-
-    :param results: List of benchmark results.
-    :param OS_RELEASE: OS release version (e.g., "Ubuntu 20.04").
-    :return: List of summarized results.
+    Creates a combined summary with both high-level totals AND detailed sub-test scores.
+    Includes CSV version tracking for backward compatibility.
     """
-    ret_results = []
+    final_sheet_data = []
 
-    # Sort and group data
-    results = list(filter(None, results))
-    sort_data(results)
-    results = group_data(results)
+    for result_set in results:
+        if not result_set: continue
 
-    for _, items in results:
-        multi_iter = [["Multi Iterations"], ["System name", "Score-" + OS_RELEASE]]
-        single_iter = [["Single Iterations"], ["System name", "Score-" + OS_RELEASE]]
-        cal_data = [["System name", "Test_passes-" + OS_RELEASE]]
-        items = list(items)
+        system_name = result_set[0][1]
+        csv_version = result_set[1][1] if len(result_set) > 1 and result_set[1][0] == 'CSV_Version' else '1.0'
 
-        # Sort data by instance size
-        sorted_data = sorted(items, key=lambda x: mk_int(process_instance(x[1][0], "size")))
+        # Data rows start after System and CSV_Version metadata
+        header_idx = 2 if csv_version else 1
+        data_rows = result_set[header_idx + 1:]
+        
+        # --- Part 1: Get High-Level Total Scores ---
+        total_multi_score, total_single_score = 0.0, 0.0
+        for row in data_rows:
+            if row[0].lower() == 'score':
+                total_multi_score = float(row[1])
+                total_single_score = float(row[2])
+                break
+        
+        cph, single_pps = calc_price_performance(system_name, total_single_score)
+        _, multi_pps = calc_price_performance(system_name, total_multi_score)
 
-        # Collect cost per hour and price performance data
-        cost_per_hour, price_perf_single, price_perf_multi = [], [], []
-        for item in sorted_data:
-            for index in range(3, len(item)):
-                multi_iter.append([item[1][0], item[index][1]])
-                single_iter.append([item[1][0], item[index][2]])
+        # --- Part 2: Get Detailed Sub-test Scores ---
+        single_iter_details = []
+        multi_iter_details = []
+        for row in data_rows:
+            if row[0].lower() == 'score': continue
+            single_iter_details.append([row[0], float(row[2])])
+            multi_iter_details.append([row[0], float(row[1])])
 
-                try:
-                    cph, ppm = calc_price_performance(item[1][0], item[index][1])
-                    cph, pps = calc_price_performance(item[1][0], item[index][2])
-                except Exception as exc:
-                    custom_logger.error(str(exc))
-                    break
+        # --- Part 3: Assemble All Tables for the Sheet ---
+        # High-Level Summary Tables (include CSV version in first table only for tracking)
+        final_sheet_data.extend([["Single Iterations"], ["System name", f"Score-{OS_RELEASE}", "CSV Version"], [system_name, total_single_score, csv_version], [""]])
+        final_sheet_data.extend([["Multi Iterations"], ["System name", f"Score-{OS_RELEASE}"], [system_name, total_multi_score], [""]])
+        final_sheet_data.extend([["Cost/Hr"], ["System name", "Cost/Hr"], [system_name, cph], [""]])
+        final_sheet_data.extend([["Single Iterations Price-perf"], ["System name", f"Score/$-{OS_RELEASE}"], [system_name, single_pps], [""]])
+        final_sheet_data.extend([["Multi Iterations Price-perf"], ["System name", f"Score/$-{OS_RELEASE}"], [system_name, multi_pps], [""]])
+        
+        # Detailed Sub-test Tables
+        final_sheet_data.extend([["Single Iterations Details"], ["Test", f"Score-{OS_RELEASE}"]] + single_iter_details)
+        final_sheet_data.append([""])
+        final_sheet_data.extend([["Multi Iterations Details"], ["Test", f"Score-{OS_RELEASE}"]] + multi_iter_details)
+        final_sheet_data.append([""])
 
-                price_perf_multi.append([item[1][0], ppm])
-                price_perf_single.append([item[1][0], pps])
-                cost_per_hour.append([item[1][0], cph])
-
-        # Prepare the final result for this item
-        final_results = [[""]]
-        final_results += single_iter
-        final_results.append([""])
-        final_results.append(["Cost/Hr"])
-        final_results += cost_per_hour
-        final_results.extend([[""], ["Single Iterations"]])
-        final_results.append(["Price-perf", f"Score/$-{OS_RELEASE}"])
-        final_results += price_perf_single
-        final_results += [[""]]
-        final_results += multi_iter
-        final_results.extend([[""], ["Multi Iterations"]])
-        final_results.append(["Price-perf", f"Score/$-{OS_RELEASE}"])
-        final_results += price_perf_multi
-        ret_results.extend(final_results)
-
-    return ret_results
-
-
-def extract_coremark_pro_data(path, system_name, OS_RELEASE):
-    """
-    Extract CoreMark Pro data from a CSV file, process it, and return the formatted results.
-
-    :param path: Path to the CSV file containing the benchmark results.
-    :param system_name: Name of the system being tested.
-    :param OS_RELEASE: OS release version (e.g., "Ubuntu 20.04").
-    :return: Processed results.
-    """
-    results = []
-    processed_data = []
-
-    # Extract data from file
-    try:
-        if path.endswith(".csv"):
-            with open(path) as file:
-                coremark_pro_results = file.readlines()
-        else:
-            return None, None
-    except Exception as exc:
-        custom_logger.debug(str(exc))
-        custom_logger.error("Unable to extract data from csv file for CoreMark Pro")
-        return None, None
-
-    data_index = 0
-    header = []
-
-    # Parse the CSV data
-    for index, data in enumerate(coremark_pro_results):
-        if "Test:Multi iterations:Single Iterations:Scaling" in data:
-            data_index = index
-            header = data.strip("\n").split(":")
-        else:
-            coremark_pro_results[index] = data.strip("\n").split(":")
-
-    coremark_pro_results = [header] + coremark_pro_results[data_index + 1:]
-
-    # Format the data into the structure we need
-    for row in coremark_pro_results:
-        if "Test" in row:
-            processed_data.append([""])
-            processed_data.append([system_name])
-            processed_data.append([row[0], row[1], row[2]])
-        elif "Score" in row:
-            processed_data.append(["Score", row[1], row[2]])
-
-    results.append(processed_data)
-    return results
+    return final_sheet_data

--- a/quisby/benchmarks/coremark_pro/coremark_pro.py
+++ b/quisby/benchmarks/coremark_pro/coremark_pro.py
@@ -50,7 +50,7 @@ def _extract_v1_format(path, system_name, OS_RELEASE, version_info):
     """
     Extract CoreMark-Pro data in v1.x CSV format.
 
-    Format: colon-delimited CSV with # commented metadata
+    Format: comma-delimited CSV with # commented metadata
     """
     try:
         if not path.endswith(".csv"):
@@ -65,9 +65,9 @@ def _extract_v1_format(path, system_name, OS_RELEASE, version_info):
     for line in lines:
         if line.strip().startswith('#') or not line.strip(): continue
         if not header:
-            header = [h.strip() for h in line.strip().split(':')]
+            header = [h.strip() for h in line.strip().split(',')]
         else:
-            data_rows.append([d.strip() for d in line.strip().split(':')])
+            data_rows.append([d.strip() for d in line.strip().split(',')])
 
     if not header or not data_rows: return None
 

--- a/quisby/benchmarks/etcd/etcd.py
+++ b/quisby/benchmarks/etcd/etcd.py
@@ -4,21 +4,43 @@ from quisby.benchmarks.fio.fio import extract_fio_run_data, extract_csv_data, gr
 from quisby.benchmarks.fio.summary import create_summary_fio_run_data
 from quisby.benchmarks.fio.graph import graph_fio_run_data
 from quisby.benchmarks.fio.comparison import compare_fio_run_results
+from quisby.benchmarks.version_util import get_version_info
+from quisby import custom_logger
 
 
-def extract_etcd_data(path, system_name):
+def extract_etcd_data(path, system_name, OS_RELEASE):
+    """
+    Extract etcd data with version awareness.
+
+    Dispatches to fio's CSV extraction functions with version support.
+    """
     results = []
-
     ls_dir = os.listdir(path)
 
-    for folder in ls_dir:
+    # Get version information from the first CSV file
+    first_file = path + f"/{ls_dir[0]}/result_etcd.csv" if ls_dir else None
+    csv_version = None
+    if first_file and os.path.exists(first_file):
+        version_info = get_version_info(first_file)
+        csv_version = version_info['raw'] or '1.0'
+
+        custom_logger.debug(
+            f"Processing ETCD CSV version {version_info['raw']} "
+            f"(normalized: {version_info['normalized']})"
+        )
+
+    for idx, folder in enumerate(ls_dir):
         with open(path + f"/{folder}/result_etcd.csv") as csv_file:
             csv_data = csv_file.readlines()
             csv_data[-1] = csv_data[-1].strip()
 
-            results += extract_csv_data(csv_data, folder)
+            # Pass csv_version only for the first folder
+            if idx == 0:
+                results += extract_csv_data(csv_data, csv_version)
+            else:
+                results += extract_csv_data(csv_data)
 
-    return group_data(results, system_name)
+    return group_data(results, system_name, OS_RELEASE, csv_version)
 
 
 def create_summary_etcd_data(results):

--- a/quisby/benchmarks/fio/fio.py
+++ b/quisby/benchmarks/fio/fio.py
@@ -40,12 +40,12 @@ def extract_csv_data(csv_data, csv_version=None):
     size_value = ""
     metric = ""
     for i, line in enumerate(csv_data):
-        if line.startswith('# op:'):
-            op_value = line.split(':')[1].strip()
-        elif line.startswith('# size:'):
-            size_value = line.split(':')[1].strip()
-        if line.startswith('njobs:ndisks:iodepth:'):
-            metric = line.split(":")[-1].strip()
+        if line.startswith('# op,'):
+            op_value = line.split(',')[1].strip()
+        elif line.startswith('# size,'):
+            size_value = line.split(',')[1].strip()
+        if line.startswith('njobs,ndisks,iodepth,'):
+            metric = line.split(",")[-1].strip()
             header_line_index = i
             break
 
@@ -53,8 +53,8 @@ def extract_csv_data(csv_data, csv_version=None):
 
     try:
         for idx, line in enumerate(data_lines):
-            # Split the values in the format '1:1:1:641169.83'
-            values = line.split(":")
+            # Split the values in the format '1,1,1,641169.83'
+            values = line.split(",")
             if len(values) == 4:  # If the line contains the expected format
                 njobs, ndisks, iodepth, value = values
                 row = [f"{op_value}-{size_value}", int(njobs), int(ndisks), int(iodepth), f" {value}", metric]

--- a/quisby/benchmarks/linpack/extract.py
+++ b/quisby/benchmarks/linpack/extract.py
@@ -106,7 +106,7 @@ def _extract_v1_format(path, system_name, version_info):
     if summary_file.endswith("csv"):
         try:
             with open(summary_file, 'r') as csv_file:
-                csv_reader = csv.DictReader(csv_file, delimiter=":")
+                csv_reader = csv.DictReader(csv_file, delimiter=",")
                 list_data = list(csv_reader)
                 last_row = list_data[-1]
 

--- a/quisby/benchmarks/linpack/extract.py
+++ b/quisby/benchmarks/linpack/extract.py
@@ -5,6 +5,7 @@ import os
 import re
 from quisby.pricing.cloud_pricing import get_cloud_pricing, get_cloud_cpu_count
 from quisby.util import read_config
+from quisby.benchmarks.version_util import get_version_info
 
 # Setting up logger for better error tracking and debugging
 logger = logging.getLogger(__name__)
@@ -73,9 +74,9 @@ def linpack_format_data(**kwargs):
     return results
 
 
-def extract_linpack_data(path, system_name):
+def _extract_v1_format(path, system_name, version_info):
     """
-    Extracts Linpack summary data from files and formats it for analysis.
+    Extract Linpack data in v1.x CSV format.
 
     This function handles the extraction of data from Linpack summary files
     and provides information about GFLOPS and the number of cores used.
@@ -83,6 +84,7 @@ def extract_linpack_data(path, system_name):
     Args:
         path (str): Path to the directory containing Linpack summary files.
         system_name (str): Name of the system being tested.
+        version_info (dict): Version information from CSV
 
     Returns:
         tuple: A tuple containing:
@@ -142,4 +144,45 @@ def extract_linpack_data(path, system_name):
             gflops=gflops
         )
 
+    # Add version info to results
+    if results:
+        csv_version = version_info['raw'] or '1.0'
+        for result in results:
+            if isinstance(result, list):
+                result.append(csv_version)
+
     return results
+
+
+def extract_linpack_data(path, system_name):
+    """
+    Extract Linpack data with version awareness.
+
+    Dispatches to appropriate handler based on CSV version.
+    Supports backward compatibility for older CSV formats.
+
+    Args:
+        path (str): Path to the directory containing Linpack summary files.
+        system_name (str): Name of the system being tested.
+
+    Returns:
+        list: Processed Linpack results with version info
+    """
+    # Get version information from CSV
+    version_info = get_version_info(path)
+    normalized_version = version_info['normalized']
+
+    logger.debug(
+        f"Processing Linpack CSV version {version_info['raw']} "
+        f"(normalized: {normalized_version})"
+    )
+
+    # Dispatch to version-specific handler
+    if normalized_version in ['1.0', '1.1']:
+        return _extract_v1_format(path, system_name, version_info)
+    else:
+        # Future: Add elif for version '2.0', '3.0', etc.
+        logger.warning(
+            f"Unknown CSV version {normalized_version}, attempting v1.x format"
+        )
+        return _extract_v1_format(path, system_name, version_info)

--- a/quisby/benchmarks/linpack/summary.py
+++ b/quisby/benchmarks/linpack/summary.py
@@ -109,7 +109,18 @@ def create_summary_linpack_data(results, os_release):
         list: The summarized results, including headers and computed values.
     """
     sorted_results = []
-    header = [
+    header_with_version = [
+        [
+            "System",
+            "Cores",
+            f"GFLOPS-{os_release}",
+            f"GFLOP Scaling-{os_release}",
+            "Cost/hr",
+            f"Price-perf-{os_release}",
+            "CSV Version",
+        ]
+    ]
+    header_without_version = [
         [
             "System",
             "Cores",
@@ -123,6 +134,7 @@ def create_summary_linpack_data(results, os_release):
     results = list(filter(None, results))  # Remove any None entries
     sort_data(results)
 
+    first_group = True
     for _, items in group_data(results):
         items = list(items)
         sorted_data = sorted(items, key=lambda x: mk_int(process_instance(x[0], "size")))
@@ -142,6 +154,15 @@ def create_summary_linpack_data(results, os_release):
                 sorted_data[index][3] = format(gflops_scaling, ".4f")
 
         res = [item for item in sorted_data]
-        sorted_results += header + res
+        # Add CSV Version header only for the first group
+        if first_group:
+            sorted_results += header_with_version + res
+            first_group = False
+        else:
+            # Remove csv_version from subsequent group rows to match header
+            for row in res:
+                if len(row) > 6:
+                    row.pop()  # Remove the last element (csv_version)
+            sorted_results += header_without_version + res
 
     return sorted_results

--- a/quisby/benchmarks/passmark/passmark.py
+++ b/quisby/benchmarks/passmark/passmark.py
@@ -5,6 +5,7 @@ from quisby import custom_logger
 from quisby.util import read_config
 from quisby.pricing.cloud_pricing import get_cloud_pricing
 from quisby.util import process_instance, mk_int
+from quisby.benchmarks.version_util import get_version_info
 
 
 def extract_prefix_and_number(input_string):
@@ -156,15 +157,8 @@ def create_summary_passmark_data(data, OS_RELEASE):
     return ret_results
 
 
-def extract_passmark_data(path, system_name, OS_RELEASE):
-    """
-    Extract and process PassMark benchmark data from a CSV file.
-
-    :param path: Path to the CSV file containing the benchmark results.
-    :param system_name: Name of the system being tested.
-    :param OS_RELEASE: OS release version (e.g., "Ubuntu 20.04").
-    :return: Processed results as a list.
-    """
+def _extract_passmark_v1(path, system_name, OS_RELEASE, version_info):
+    """Extract PassMark data in v1.x format."""
     results = []
 
     # Extract data from file
@@ -178,17 +172,56 @@ def extract_passmark_data(path, system_name, OS_RELEASE):
         custom_logger.error(f"Error reading file {path}: {str(exc)}")
         return None
 
+    # Add version metadata
+    csv_version = version_info['raw'] or '1.0'
+
     data_index = 0
     header = []
     for index, data in enumerate(passmark_results):
         if "NumTestProcesses:" in data:
             header = data.strip("\n").split(":")
+            # Add CSV Version to header
+            header.append("CSV Version")
             data_index = index
         else:
             passmark_results[index] = data.strip("\n").split(":")
+
+    # Add csv_version only to the first data row
+    for idx, row in enumerate(passmark_results[data_index + 1:]):
+        if idx == 0 and isinstance(row, list):
+            row.append(csv_version)
 
     passmark_results = [header] + passmark_results[data_index + 1:]
     results.append([""])
     results.append([system_name])
     results.extend(passmark_results)
     return [results]
+
+
+def extract_passmark_data(path, system_name, OS_RELEASE):
+    """
+    Extract and process PassMark benchmark data from a CSV file with version awareness.
+
+    :param path: Path to the CSV file containing the benchmark results.
+    :param system_name: Name of the system being tested.
+    :param OS_RELEASE: OS release version (e.g., "Ubuntu 20.04").
+    :return: Processed results as a list.
+    """
+    # Get version information from CSV
+    version_info = get_version_info(path)
+    normalized_version = version_info['normalized']
+
+    custom_logger.debug(
+        f"Processing PassMark CSV version {version_info['raw']} "
+        f"(normalized: {normalized_version})"
+    )
+
+    # Dispatch to version-specific handler
+    if normalized_version in ['1.0', '1.1']:
+        return _extract_passmark_v1(path, system_name, OS_RELEASE, version_info)
+    else:
+        # Future: Add elif for version '2.0', '3.0', etc.
+        custom_logger.warning(
+            f"Unknown CSV version {normalized_version}, attempting v1.x format"
+        )
+        return _extract_passmark_v1(path, system_name, OS_RELEASE, version_info)

--- a/quisby/benchmarks/passmark/passmark.py
+++ b/quisby/benchmarks/passmark/passmark.py
@@ -178,13 +178,13 @@ def _extract_passmark_v1(path, system_name, OS_RELEASE, version_info):
     data_index = 0
     header = []
     for index, data in enumerate(passmark_results):
-        if "NumTestProcesses:" in data:
-            header = data.strip("\n").split(":")
+        if "NumTestProcesses," in data:
+            header = data.strip("\n").split(",")
             # Add CSV Version to header
             header.append("CSV Version")
             data_index = index
         else:
-            passmark_results[index] = data.strip("\n").split(":")
+            passmark_results[index] = data.strip("\n").split(",")
 
     # Add csv_version only to the first data row
     for idx, row in enumerate(passmark_results[data_index + 1:]):

--- a/quisby/benchmarks/phoronix/phoronix.py
+++ b/quisby/benchmarks/phoronix/phoronix.py
@@ -198,13 +198,13 @@ def _extract_phoronix_v1(path, system_name, OS_RELEASE, version_info):
     data_index = 0
     header = []
     for index, data in enumerate(phoronix_results):
-        if "Test:BOPs" in data:
+        if "Test,BOPs" in data:
             data_index = index
-            header = data.strip("\n").split(":")
+            header = data.strip("\n").split(",")
             # Add CSV Version to header
             header.append("CSV Version")
         else:
-            phoronix_results[index] = data.strip("\n").split(":")
+            phoronix_results[index] = data.strip("\n").split(",")
 
     # Add csv_version only to the first data row
     for idx, row in enumerate(phoronix_results[data_index + 1:]):

--- a/quisby/benchmarks/phoronix/phoronix.py
+++ b/quisby/benchmarks/phoronix/phoronix.py
@@ -5,6 +5,7 @@ from quisby.util import read_config
 from quisby.pricing.cloud_pricing import get_cloud_pricing
 import re
 from quisby.util import process_instance, mk_int
+from quisby.benchmarks.version_util import get_version_info
 
 
 def extract_prefix_and_number(input_string):
@@ -175,9 +176,53 @@ def create_summary_phoronix_data(data, OS_RELEASE):
     return ret_results
 
 
+def _extract_phoronix_v1(path, system_name, OS_RELEASE, version_info):
+    """Extract Phoronix data in v1.x format."""
+    results = []
+
+    # Extract data from file
+    try:
+        if path.endswith("results.csv"):
+            with open(path) as file:
+                phoronix_results = file.readlines()
+        else:
+            return None
+    except Exception as exc:
+        custom_logger.error(str(exc))
+        return None
+
+    # Add version metadata
+    csv_version = version_info['raw'] or '1.0'
+
+    # Extract header and data
+    data_index = 0
+    header = []
+    for index, data in enumerate(phoronix_results):
+        if "Test:BOPs" in data:
+            data_index = index
+            header = data.strip("\n").split(":")
+            # Add CSV Version to header
+            header.append("CSV Version")
+        else:
+            phoronix_results[index] = data.strip("\n").split(":")
+
+    # Add csv_version only to the first data row
+    for idx, row in enumerate(phoronix_results[data_index + 1:]):
+        if idx == 0 and isinstance(row, list):
+            row.append(csv_version)
+
+    # Combine header and data, and append the system name
+    phoronix_results = [header] + phoronix_results[data_index + 1:]
+    results.append([""])
+    results.append([system_name])
+    results.extend(phoronix_results[1:])
+
+    return [results]
+
+
 def extract_phoronix_data(path, system_name, OS_RELEASE):
     """
-    Extracts Phoronix benchmark data from a file and formats it for further processing.
+    Extracts Phoronix benchmark data from a file with version awareness.
 
     Args:
         path (str): The path to the results file.
@@ -187,74 +232,21 @@ def extract_phoronix_data(path, system_name, OS_RELEASE):
     Returns:
         list: A list containing the extracted data.
     """
-    results = []
+    # Get version information from CSV
+    version_info = get_version_info(path)
+    normalized_version = version_info['normalized']
 
-    # Extract data from file - accept any CSV file, not just those ending with "results.csv"
-    try:
-        if path.endswith(".csv"):
-            with open(path) as file:
-                lines = file.readlines()
-        else:
-            custom_logger.error(f"File {path} is not a CSV file")
-            return None
-    except Exception as exc:
-        custom_logger.error(str(exc))
-        return None
+    custom_logger.debug(
+        f"Processing Phoronix CSV version {version_info['raw']} "
+        f"(normalized: {normalized_version})"
+    )
 
-    # Find the subtest marker to identify which subtest we're processing
-    subtest_start_index = None
-    subtest_name = None
-    for i, line in enumerate(lines):
-        if line.startswith("# Subtest:"):
-            subtest_start_index = i
-            subtest_name = line.split(":", 1)[1].strip()
-            break
-    
-    if subtest_start_index is None:
-        custom_logger.error("Could not find '# Subtest:' marker in the file")
-        return None
-
-    # Find the header line after the subtest marker
-    header_start_index = None
-    for i in range(subtest_start_index + 1, len(lines)):
-        line = lines[i].strip()
-        if line and not line.startswith("#") and ":" in line:
-            # Check if this looks like a header (contains multiple colons and descriptive terms)
-            parts = line.split(":")
-            if len(parts) >= 2 and any(keyword in line.lower() for keyword in ["test", "average", "deviation", "bops"]):
-                header_start_index = i
-                break
-    
-    if header_start_index is None:
-        custom_logger.error("Could not find header line after subtest marker")
-        return None
-
-    # Extract header from the header line
-    header_line = lines[header_start_index].strip()
-    header = header_line.split(":")
-    
-    # Extract data entries (handle both 2-column and 3-column formats)
-    data_entries = []
-    for i in range(header_start_index + 1, len(lines)):
-        line = lines[i].strip()
-        if line and not line.startswith("#"):  # Skip empty lines and comments
-            parts = line.split(":")
-            if len(parts) >= 2:
-                # For stress-ng format (Test:Average:Deviation), use the test name and average value
-                # For other formats, use the first two parts
-                test_name = parts[0]
-                test_value = parts[1]
-                data_entries.append([test_name, test_value])
-            else:
-                custom_logger.warning(f"Skipping malformed line {i+1}: '{line}'")
-
-    # Create properly structured results for summary function compatibility
-    # The summary function expects: row[1][0] = system_name, row[i][1] = test_values (i >= 2)
-    results.append([""])  # Empty row for formatting
-    results.append([f"{system_name}-{subtest_name}"])  # System identifier row with subtest name
-    
-    # Transform data entries into the expected format: [test_name, value] -> [test_name, [value]]
-    for test_name, value in data_entries:
-        results.append([test_name, value])
-
-    return [results]
+    # Dispatch to version-specific handler
+    if normalized_version in ['1.0', '1.1']:
+        return _extract_phoronix_v1(path, system_name, OS_RELEASE, version_info)
+    else:
+        # Future: Add elif for version '2.0', '3.0', etc.
+        custom_logger.warning(
+            f"Unknown CSV version {normalized_version}, attempting v1.x format"
+        )
+        return _extract_phoronix_v1(path, system_name, OS_RELEASE, version_info)

--- a/quisby/benchmarks/speccpu/extract.py
+++ b/quisby/benchmarks/speccpu/extract.py
@@ -11,7 +11,7 @@ def _process_speccpu_v1(path, system_name, suite, OS_RELEASE, version_info):
     results = []
 
     with open(path) as csv_file:
-        speccpu_results = list(csv.DictReader(csv_file, delimiter=":"))
+        speccpu_results = list(csv.DictReader(csv_file, delimiter=","))
 
     # Add version metadata
     csv_version = version_info['raw'] or '1.0'

--- a/quisby/benchmarks/speccpu/extract.py
+++ b/quisby/benchmarks/speccpu/extract.py
@@ -3,20 +3,29 @@ import csv
 from quisby import custom_logger
 
 from quisby.util import read_config
+from quisby.benchmarks.version_util import get_version_info
 
 
-def process_speccpu(path, system_name, suite, OS_RELEASE):
+def _process_speccpu_v1(path, system_name, suite, OS_RELEASE, version_info):
+    """Process SPECCPU data in v1.x format."""
     results = []
 
     with open(path) as csv_file:
         speccpu_results = list(csv.DictReader(csv_file, delimiter=":"))
 
+    # Add version metadata
+    csv_version = version_info['raw'] or '1.0'
+
     results.append([""])
     results.append([system_name, suite])
-    results.append(["Benchmark", f"Base_Rate-{OS_RELEASE}"])
-    for data_row in speccpu_results:
+    results.append(["Benchmark", f"Base_Rate-{OS_RELEASE}", "CSV Version"])
+    for idx, data_row in enumerate(speccpu_results):
         try:
-            results.append([data_row['Benchmarks'], data_row['Base Rate']])
+            # Add csv_version only to the first data row
+            if idx == 0:
+                results.append([data_row['Benchmarks'], data_row['Base Rate'], csv_version])
+            else:
+                results.append([data_row['Benchmarks'], data_row['Base Rate']])
         except Exception as exc:
             custom_logger.debug(str(exc))
             pass
@@ -24,13 +33,40 @@ def process_speccpu(path, system_name, suite, OS_RELEASE):
 
 
 def extract_speccpu_data(path, system_name, OS_RELEASE):
+    """
+    Extract SPECCPU data with version awareness.
+
+    Dispatches to appropriate handler based on CSV version.
+    Supports backward compatibility for older CSV formats.
+    """
+    # Get version information from CSV
+    version_info = get_version_info(path)
+    normalized_version = version_info['normalized']
+
+    custom_logger.debug(
+        f"Processing SPECCPU CSV version {version_info['raw']} "
+        f"(normalized: {normalized_version})"
+    )
+
     results = []
-    summary_data = []
-    if "fprate" in path:
-        fp_results = process_speccpu(path, system_name, "fprate", OS_RELEASE)
-        results += fp_results
-    elif "intrate" in path:
-        int_results = process_speccpu(path, system_name, "intrate", OS_RELEASE)
-        results += int_results
+    # Dispatch to version-specific handler
+    if normalized_version in ['1.0', '1.1']:
+        if "fprate" in path:
+            fp_results = _process_speccpu_v1(path, system_name, "fprate", OS_RELEASE, version_info)
+            results += fp_results
+        elif "intrate" in path:
+            int_results = _process_speccpu_v1(path, system_name, "intrate", OS_RELEASE, version_info)
+            results += int_results
+    else:
+        # Future: Add elif for version '2.0', '3.0', etc.
+        custom_logger.warning(
+            f"Unknown CSV version {normalized_version}, attempting v1.x format"
+        )
+        if "fprate" in path:
+            fp_results = _process_speccpu_v1(path, system_name, "fprate", OS_RELEASE, version_info)
+            results += fp_results
+        elif "intrate" in path:
+            int_results = _process_speccpu_v1(path, system_name, "intrate", OS_RELEASE, version_info)
+            results += int_results
 
     return results

--- a/quisby/benchmarks/specjbb/specjbb.py
+++ b/quisby/benchmarks/specjbb/specjbb.py
@@ -150,7 +150,7 @@ def _extract_specjbb_v1(path, system_name, OS_RELEASE, version_info):
         # Fetch values from the last index to the end
         line = specjbb_results[data_index[-1]+1:-1]
         for idx, values in enumerate(line):
-            row = values.strip().split(":")
+            row = values.strip().split(",")
             # Add csv_version only to the first data row
             if idx == 0:
                 row.append(csv_version)
@@ -159,7 +159,7 @@ def _extract_specjbb_v1(path, system_name, OS_RELEASE, version_info):
         for i in range(len(data_index) - 1):
             line = specjbb_results[data_index[i]+1:data_index[i+1]-1]
             for idx, values in enumerate(line):
-                row = values.strip().split(":")
+                row = values.strip().split(",")
                 # Add csv_version only to the first data row
                 if idx == 0:
                     row.append(csv_version)

--- a/quisby/benchmarks/streams/streams.py
+++ b/quisby/benchmarks/streams/streams.py
@@ -6,6 +6,7 @@ from quisby.util import mk_int, process_instance
 from quisby import custom_logger
 from quisby.pricing.cloud_pricing import get_cloud_pricing
 from quisby.util import read_config
+from quisby.benchmarks.version_util import get_version_info
 
 
 def stream_sort_data_by_system_family(results):
@@ -123,17 +124,16 @@ def create_summary_streams_data(stream_data, OS_RELEASE):
     return results
 
 
-def extract_streams_data(path, system_name, OS_RELEASE):
+def _extract_v1_format(path, system_name, OS_RELEASE, version_info):
     """
-    Extracts streams data and appends empty list for each seperate stream runs
+    Extract streams data in v1.x format.
 
     :path: stream summary results file from stream_wrapper_benchmark runs
     :system_name: machine name (eg: m5.2xlarge, Standard_D64s_v3)
+    :version_info: Version information from CSV
     """
-
     summary_data = []
     summary_file = path
-
 
     if not os.path.isfile(summary_file):
         return None
@@ -141,14 +141,11 @@ def extract_streams_data(path, system_name, OS_RELEASE):
     with open(path) as file:
         streams_results = file.readlines()
 
-
     data_index = 0
     for index, data in enumerate(streams_results):
         if "buffer size" in data:
             data_index = index
         streams_results[index] = data.strip("\n").split(":")
-
-    # streams_results = sorted(streams_results[data_index + 1 :], key=lambda x: x[2])
 
     socket_number = ""
     proccessed_data = []
@@ -157,6 +154,11 @@ def extract_streams_data(path, system_name, OS_RELEASE):
     memory = ""
     if not streams_results:
         return None
+
+    # Add version metadata at the beginning
+    csv_version = version_info['raw'] or '1.0'
+    proccessed_data.append(['CSV_Version', csv_version])
+
     for i in range(0, length):
         row = streams_results[i]
         if "memory" in row[0]:
@@ -188,6 +190,36 @@ def extract_streams_data(path, system_name, OS_RELEASE):
             proccessed_data[pos - 5].append(memory + "-" + OS_RELEASE)
             proccessed_data[data_pos].extend(row[1:])
     return proccessed_data
+
+
+def extract_streams_data(path, system_name, OS_RELEASE):
+    """
+    Extract streams data with version awareness.
+
+    Dispatches to appropriate handler based on CSV version.
+    Supports backward compatibility for older CSV formats.
+
+    :path: stream summary results file from stream_wrapper_benchmark runs
+    :system_name: machine name (eg: m5.2xlarge, Standard_D64s_v3)
+    """
+    # Get version information from CSV
+    version_info = get_version_info(path)
+    normalized_version = version_info['normalized']
+
+    custom_logger.debug(
+        f"Processing Streams CSV version {version_info['raw']} "
+        f"(normalized: {normalized_version})"
+    )
+
+    # Dispatch to version-specific handler
+    if normalized_version in ['1.0', '1.1']:
+        return _extract_v1_format(path, system_name, OS_RELEASE, version_info)
+    else:
+        # Future: Add elif for version '2.0', '3.0', etc.
+        custom_logger.warning(
+            f"Unknown CSV version {normalized_version}, attempting v1.x format"
+        )
+        return _extract_v1_format(path, system_name, OS_RELEASE, version_info)
 
 
 if __name__ == "__main__":

--- a/quisby/benchmarks/streams/streams.py
+++ b/quisby/benchmarks/streams/streams.py
@@ -145,7 +145,7 @@ def _extract_v1_format(path, system_name, OS_RELEASE, version_info):
     for index, data in enumerate(streams_results):
         if "buffer size" in data:
             data_index = index
-        streams_results[index] = data.strip("\n").split(":")
+        streams_results[index] = data.strip("\n").split(",")
 
     socket_number = ""
     proccessed_data = []

--- a/quisby/benchmarks/uperf/uperf.py
+++ b/quisby/benchmarks/uperf/uperf.py
@@ -186,8 +186,8 @@ def _extract_v1_format(path, system_name, version_info):
     header_line_index = []
     for data in csv_reader:
         for i, line in enumerate(data):
-            if line.startswith('Instance_Count:'):
-                metric = line.split(":")[-1].strip()
+            if line.startswith('Instance_Count,'):
+                metric = line.split(",")[-1].strip()
                 header_line_index.append((i,metric))
 
     # Add version metadata
@@ -199,8 +199,8 @@ def _extract_v1_format(path, system_name, version_info):
         try:
             instance_data = []
             for line in data_lines:
-                # Split the values in the format '1:1:1:641169.83'
-                values = line.split(":")
+                # Split the values in the format '1,1,1,641169.83'
+                values = line.split(",")
                 if len(values) == 5:  # If the line contains the expected format
                     intance_count, value, test_type, packet_type, packet_size = values
                     instance_data.append([f"{intance_count}i", value.strip()])

--- a/quisby/benchmarks/version_util.py
+++ b/quisby/benchmarks/version_util.py
@@ -1,0 +1,203 @@
+"""
+CSV Version Utilities for Quisby
+
+Provides version parsing and management for benchmark CSV files.
+Ensures backward compatibility when CSV formats change.
+
+Usage Example:
+    from quisby.benchmarks.version_util import (
+        get_version_info,
+        version_dispatch
+    )
+
+    def extract_benchmark_data(path, system_name, OS_RELEASE):
+        # Dispatch based on version
+        version_info = get_version_info(path)
+
+        if version_info['normalized'] in ['1.0', '1.1']:
+            return _extract_v1_format(path, system_name, OS_RELEASE, version_info)
+        elif version_info['normalized'] == '2.0':
+            return _extract_v2_format(path, system_name, OS_RELEASE, version_info)
+        else:
+            raise ValueError(f"Unsupported version: {version_info['raw']}")
+
+    # Or use the helper:
+    def extract_benchmark_data(path, system_name, OS_RELEASE):
+        return version_dispatch(
+            path,
+            handlers={
+                '1.0': _extract_v1_format,
+                '1.1': _extract_v1_format,  # v1.1 compatible with v1.0
+                '2.0': _extract_v2_format,
+            },
+            args=(system_name, OS_RELEASE)
+        )
+"""
+
+import re
+from quisby import custom_logger
+
+
+def parse_csv_version(file_path):
+    """
+    Parse the CSV version from the file metadata.
+
+    Looks for '# Results version: <version>' in the CSV file header.
+
+    :param file_path: Path to the CSV file
+    :return: Version string (e.g., 'v1.1.2743', '1.0') or None if not found
+    """
+    try:
+        with open(file_path, 'r') as file:
+            for line in file:
+                line = line.strip()
+
+                # Stop searching after metadata section
+                if line == '# Test general meta end':
+                    break
+
+                # Look for version line
+                if line.startswith('# Results version:'):
+                    version = line.split(':', 1)[1].strip()
+                    return version
+
+        # No version found - assume legacy format
+        custom_logger.debug(f"No version found in {file_path}, assuming v1.0")
+        return None
+
+    except Exception as exc:
+        custom_logger.error(f"Error parsing version from {file_path}: {exc}")
+        return None
+
+
+def parse_csv_metadata(file_path):
+    """
+    Parse all metadata from CSV file header.
+
+    Returns a dictionary with all metadata fields from the CSV header.
+
+    :param file_path: Path to the CSV file
+    :return: Dictionary of metadata key-value pairs
+    """
+    metadata = {}
+
+    try:
+        with open(file_path, 'r') as file:
+            in_metadata = False
+
+            for line in file:
+                line = line.strip()
+
+                # Track metadata sections
+                if line == '# Test general meta start':
+                    in_metadata = True
+                    continue
+                elif line == '# Test general meta end':
+                    break
+
+                # Parse metadata lines
+                if in_metadata and line.startswith('#'):
+                    # Remove leading '#' and split on first ':'
+                    content = line[1:].strip()
+                    if ':' in content:
+                        key, value = content.split(':', 1)
+                        metadata[key.strip()] = value.strip()
+
+        return metadata
+
+    except Exception as exc:
+        custom_logger.error(f"Error parsing metadata from {file_path}: {exc}")
+        return {}
+
+
+def normalize_version(version_string):
+    """
+    Normalize version string to comparable format.
+
+    Examples:
+        'v1.1.2743' -> '1.1'
+        '2.0.1' -> '2.0'
+        None -> '1.0'
+
+    :param version_string: Raw version string from CSV
+    :return: Normalized version string (major.minor)
+    """
+    if not version_string:
+        return '1.0'
+
+    # Remove 'v' prefix if present
+    version_string = version_string.lstrip('vV')
+
+    # Extract major.minor version
+    match = re.match(r'^(\d+)\.(\d+)', version_string)
+    if match:
+        return f"{match.group(1)}.{match.group(2)}"
+
+    # Fallback
+    return '1.0'
+
+
+def get_version_info(file_path):
+    """
+    Get comprehensive version information from CSV file.
+
+    :param file_path: Path to the CSV file
+    :return: Dictionary with 'raw', 'normalized', and 'metadata' keys
+    """
+    raw_version = parse_csv_version(file_path)
+    normalized = normalize_version(raw_version)
+    metadata = parse_csv_metadata(file_path)
+
+    return {
+        'raw': raw_version,
+        'normalized': normalized,
+        'metadata': metadata
+    }
+
+
+def version_dispatch(path, handlers, args=(), kwargs=None, default_version='1.0'):
+    """
+    Dispatch CSV extraction to version-specific handler.
+
+    This helper function parses the CSV version and calls the appropriate handler.
+
+    :param path: Path to the CSV file
+    :param handlers: Dictionary mapping version strings to handler functions
+                     Example: {'1.0': extract_v1, '2.0': extract_v2}
+    :param args: Positional arguments to pass to the handler
+    :param kwargs: Keyword arguments to pass to the handler
+    :param default_version: Version to use if CSV has no version (default: '1.0')
+    :return: Result from the version-specific handler, with version info attached
+    """
+    if kwargs is None:
+        kwargs = {}
+
+    # Get version info
+    version_info = get_version_info(path)
+    normalized_version = version_info['normalized']
+    raw_version = version_info['raw'] or default_version
+
+    # Find appropriate handler
+    if normalized_version in handlers:
+        handler = handlers[normalized_version]
+        custom_logger.debug(f"Using version {normalized_version} handler for {path}")
+    elif default_version in handlers:
+        handler = handlers[default_version]
+        custom_logger.warning(
+            f"No handler for version {normalized_version} ({raw_version}), "
+            f"using default v{default_version} handler for {path}"
+        )
+    else:
+        raise ValueError(
+            f"Unsupported CSV version {normalized_version} ({raw_version}) "
+            f"and no default handler available. Supported versions: {list(handlers.keys())}"
+        )
+
+    # Call the handler
+    result = handler(path, *args, **kwargs)
+
+    # Attach version info to result for downstream tracking
+    if result is not None and isinstance(result, dict):
+        result['csv_version'] = raw_version
+
+    return result


### PR DESCRIPTION
# Description
  This PR adds a CSV versioning system to Quisby benchmark extractors, enabling backward compatibility when wrapper scripts change their CSV output format. Previously, updating wrappers would break Quisby's ability to process older CSV files. Now, Quisby automatically detects the CSV version and uses the appropriate parser, allowing it to process CSVs from any wrapper version.

# Before/After Comparison
  ## Before (No Versioning)                                                                                                                                                                   
                                                                                                                                                                                              
  **Scenario:** Wrapper changes CSV format from colon-delimited to pipe-delimited                                                                                                             
                                                                                                                                                                                              
  Old CSV (v1.0 format)                                                                                                                                                                       
                                                                                                                                                                                              
  Test:Score:Iterations                                                                                                                                                                       
  test1:100:50                                                                                                                                                                                
                                                                                                                                                                                              
  New CSV (v2.0 format)                                                                                                                                                                       
                                                                                                                                                                                              
  Test,Score,Iterations,NewColumn                                                                                                                                                             
  test1,100,50,extra                                                                                                                                                                          
                                                                                                                                                                                              
  **Problem:**                                                                                                                                                                                
  - Update Quisby to handle v2.0 format → Old v1.0 CSVs fail to parse 
  - Keep old Quisby version → New v2.0 CSVs fail to parse                                                                                                                                 
  - Only solution: Delete old CSVs or maintain multiple Quisby versions                                                                                                                       
                                                                                                                                                                                                                                                                                                                                 
  ## After (With Versioning)                                                                                                                                                                  
                                                                                                                                                                                              
  **Same Scenario:** Wrapper changes CSV format                                                                                                                                               
                                                                                                                                                                                              
  **Solution:**                                                                                                                                                                               
  - Quisby automatically detects version from CSV metadata                                                                                                                                    
  - Routes to appropriate parser (v1 handler or v2 handler)                                                                                                                                   
  - Both old and new CSVs work simultaneously                                                                                                            
                                                          
# Clerical Stuff
This closes #x" to close the issue out automatically.
Relates to JIRA: RPOPC-393
